### PR TITLE
Reference ACPI 6.0 and add Type-C connector

### DIFF
--- a/windows-driver-docs-pr/install/using-acpi-to-configure-usb-ports-on-a-computer.md
+++ b/windows-driver-docs-pr/install/using-acpi-to-configure-usb-ports-on-a-computer.md
@@ -9,7 +9,7 @@ ms.assetid: 999f9fef-512c-415a-abc6-d64560c5c2f8
 
 If the system requires ACPI BIOS changes to accurately reflect the USB port configuration, you should consider the user's ability to connect a device to the port when you configure the port.
 
-If you use ACPI to specify the configuration of a USB port, you must define the USB port capabilities (**\_UPC**) and physical location description (**\_PLD**) objects. Although the ACPI 3.0 specification does not specifically prohibit the use of only the **\_UPC** object, the use of both objects more precisely indicates the user's ability to connect devices to the port. Using only the **\_UPC** object might not set the device container grouping correctly or as expected.
+If you use ACPI to specify the configuration of a USB port, you must define the USB port capabilities (**\_UPC**) and physical location description (**\_PLD**) objects. Although the ACPI 6.0 specification does not specifically prohibit the use of only the **\_UPC** object, the use of both objects more precisely indicates the user's ability to connect devices to the port. Using only the **\_UPC** object might not set the device container grouping correctly or as expected.
 
 Devices that are attached to the port are removable from the hub if the **DeviceRemovable** bit is set. The following table shows how the values of the ACPI objects for a given port affect the value of the USB hub descriptor **DeviceRemovable** bit that Windows reports for the device.
 
@@ -34,14 +34,14 @@ Devices that are attached to the port are removable from the hub if the **Device
 <tr class="odd">
 <td align="left"><p>Port is visible and the user can freely connect and disconnect devices.</p></td>
 <td align="left"><p>Port is exposed on the face of a panel on the computer that is visible to the user.</p></td>
-<td align="left"><p>Set (OxFF)</p></td>
+<td align="left"><p>Set (0xFF)</p></td>
 <td align="left"><p>Set (1)</p></td>
 <td align="left"><p>Set</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Port is hidden or internal and user cannot freely connect and disconnect devices.</p></td>
 <td align="left"><p>Port is directly hard-wired to an integrated device, such as a laptop webcam or an internal USB hub.</p></td>
-<td align="left"><p>Set (OxFF)</p></td>
+<td align="left"><p>Set (0xFF)</p></td>
 <td align="left"><p>Cleared</p></td>
 <td align="left"><p>Cleared</p></td>
 </tr>
@@ -79,7 +79,7 @@ The following examples show correctly formed ACPI Source Language (ASL) that dem
         0x30, 0x1C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
     ```
 
--   To specify a port that is external (user visible) and can be connected to an external device, the **\_UPC.PortIsConnectable** byte must be set to 0xFF and the **\_PLD.UserVisible** bit must be set to 1. The \_**UPC**.**PortConnectorType** byte must be set to the appropriate USB connector type as specified in Section 9.14 of the ACPI 3.0 specification.
+-   To specify a port that is external (user visible) and can be connected to an external device, the **\_UPC.PortIsConnectable** byte must be set to 0xFF and the **\_PLD.UserVisible** bit must be set to 1. The \_**UPC**.**PortConnectorType** byte must be set to the appropriate USB connector type as specified in Section 9.13 of the ACPI 3.0 specification.
 
     In the following example the device is assigned a new device container and is displayed as a separate physical device.
 
@@ -94,8 +94,19 @@ The following examples show correctly formed ACPI Source Language (ASL) that dem
         0x81, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x31, 0x1C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
     ```
+    
+A USB Type-C connector must be correctly described in ACPI in order to pass the [USB Type-C ACPI Validation](https://msdn.microsoft.com/en-us/library/windows/hardware/mt770585(v=vs.85).aspx) Hardware Lab Kit test.
 
-For more information about the ACPI 3.0 interface, see [Advanced Configuration and Power Interface Specification Revision 3.0b](http://go.microsoft.com/fwlink/p/?linkid=145427).
+Example _UPC for a USB Type-C connector:
+```
+      Name(_UPC, Package(4){
+        0x01,                       // Port is connectable
+        0x09,                       // Connector type: Type C connector - USB2 and SS with Switch
+        0x00000000,                 // Reserved0 – must be zero
+        0x00000000})                // Reserved1 – must be zero
+```
+
+For more information about the ACPI 6.0 interface, see [Advanced Configuration and Power Interface Specification Revision 6.0](http://go.microsoft.com/fwlink/?LinkId=827852).
 
  
 


### PR DESCRIPTION
Bug 7871805:"Using ACPI to Configure USB Ports on a Computer" to reference new version of ACPI specification 