### PR TITLE
Remove bullet based on feedback

### DIFF
--- a/windows-driver-docs-pr/network/offloading-the-segmentation-of-large-tcp-packets.md
+++ b/windows-driver-docs-pr/network/offloading-the-segmentation-of-large-tcp-packets.md
@@ -105,7 +105,6 @@ In addition to the previous LSO requirements, LSOV2-capable miniport drivers mus
 
 -   Support TCP options, IP options, and IP extension headers.
 
--   Not set the **UserData** member of the [**NDIS\_TCP\_LARGE\_SEND\_OFFLOAD\_NET\_BUFFER\_LIST\_INFO**](https://msdn.microsoft.com/library/windows/hardware/ff567882) structure when a send operation is complete. Instead, the miniport driver must set the **LsoV2TransmitComplete.Reserved** member to zero and the **LsoV2TransmitComplete.Type** member to NDIS\_TCP\_LARGE\_SEND\_OFFLOAD\_V2\_TYPE.
 
  
 


### PR DESCRIPTION
Removed the last bullet point. We already say what the values should be set as depending on whether the request was v1 or v2. Thanks, @I-gor-C for the correction.