### PR TITLE
Update interlocked-operations-in-storport-miniport-drivers.md

### DIFF
--- a/windows-driver-docs-pr/storage/interlocked-operations-in-storport-miniport-drivers.md
+++ b/windows-driver-docs-pr/storage/interlocked-operations-in-storport-miniport-drivers.md
@@ -19,37 +19,37 @@ The following interlocked functions are available for use in miniport drivers.
 ## <span id="interlocked_logical"></span><span id="INTERLOCKED_LOGICAL"></span>Logical
 
 
-[**InterlockedAnd**](https://msdn.microsoft.com/library/windows/desktop/ms683516)
-[**InterlockedAnd16**](https://msdn.microsoft.com/library/windows/desktop/ms683518)
-[**InterlockedAnd64**](https://msdn.microsoft.com/library/windows/desktop/ms683527)
-[**InterlockedOr**](https://msdn.microsoft.com/library/windows/desktop/ms683626)
-[**InterlockedOr16**](https://msdn.microsoft.com/library/windows/desktop/ms683627)
-[**InterlockedOr64**](https://msdn.microsoft.com/library/windows/desktop/ms683633)
-[**InterlockedXor**](https://msdn.microsoft.com/library/windows/desktop/ms684021)
-[**InterlockedXor16**](https://msdn.microsoft.com/library/windows/desktop/ms684024)
-[**InterlockedXor64**](https://msdn.microsoft.com/library/windows/desktop/ms684104)
+[**InterlockedAnd**](https://msdn.microsoft.com/library/windows/desktop/ms683516)  
+[**InterlockedAnd16**](https://msdn.microsoft.com/library/windows/desktop/ms683518)  
+[**InterlockedAnd64**](https://msdn.microsoft.com/library/windows/desktop/ms683527)  
+[**InterlockedOr**](https://msdn.microsoft.com/library/windows/desktop/ms683626)  
+[**InterlockedOr16**](https://msdn.microsoft.com/library/windows/desktop/ms683627)  
+[**InterlockedOr64**](https://msdn.microsoft.com/library/windows/desktop/ms683633)  
+[**InterlockedXor**](https://msdn.microsoft.com/library/windows/desktop/ms684021)  
+[**InterlockedXor16**](https://msdn.microsoft.com/library/windows/desktop/ms684024)  
+[**InterlockedXor64**](https://msdn.microsoft.com/library/windows/desktop/ms684104)  
 ## <span id="interlocked_assignment"></span><span id="INTERLOCKED_ASSIGNMENT"></span>Assignment
 
 
-[**InterlockedExchange**](https://msdn.microsoft.com/library/windows/desktop/ms683590)
-[**InterlockedExchange64**](https://msdn.microsoft.com/library/windows/desktop/ms683593)
-[**InterlockedExchangePointer**](https://msdn.microsoft.com/library/windows/desktop/ms683609)
+[**InterlockedExchange**](https://msdn.microsoft.com/library/windows/desktop/ms683590)  
+[**InterlockedExchange64**](https://msdn.microsoft.com/library/windows/desktop/ms683593)  
+[**InterlockedExchangePointer**](https://msdn.microsoft.com/library/windows/desktop/ms683609)  
 ## <span id="interlocked_comparison"></span><span id="INTERLOCKED_COMPARISON"></span>Comparison
 
 
-[**InterlockedCompareExchange**](https://msdn.microsoft.com/library/windows/desktop/ms683560)
-**InterlockedCompareExchange16**
-[**InterlockedCompareExchange64**](https://msdn.microsoft.com/library/windows/desktop/ms683562)
-[**InterlockedCompareExchangePointer**](https://msdn.microsoft.com/library/windows/desktop/ms683568)
+[**InterlockedCompareExchange**](https://msdn.microsoft.com/library/windows/desktop/ms683560)  
+**InterlockedCompareExchange16**  
+[**InterlockedCompareExchange64**](https://msdn.microsoft.com/library/windows/desktop/ms683562)  
+[**InterlockedCompareExchangePointer**](https://msdn.microsoft.com/library/windows/desktop/ms683568)  
 ## <span id="interlocked_arithmetic"></span><span id="INTERLOCKED_ARITHMETIC"></span>Arithmetic
 
 
-[**InterlockedDecrement**](https://msdn.microsoft.com/library/windows/desktop/ms683580)
-[**InterlockedDecrement64**](https://msdn.microsoft.com/library/windows/desktop/ms683581)
-[**InterlockedExchangeAdd**](https://msdn.microsoft.com/library/windows/desktop/ms683597)
-[**InterlockedExchangeAdd64**](https://msdn.microsoft.com/library/windows/desktop/ms683599)
-[**InterlockedIncrement**](https://msdn.microsoft.com/library/windows/desktop/ms683614)
-[**InterlockedIncrement64**](https://msdn.microsoft.com/library/windows/desktop/ms683615)
+[**InterlockedDecrement**](https://msdn.microsoft.com/library/windows/desktop/ms683580)  
+[**InterlockedDecrement64**](https://msdn.microsoft.com/library/windows/desktop/ms683581)  
+[**InterlockedExchangeAdd**](https://msdn.microsoft.com/library/windows/desktop/ms683597)  
+[**InterlockedExchangeAdd64**](https://msdn.microsoft.com/library/windows/desktop/ms683599)  
+[**InterlockedIncrement**](https://msdn.microsoft.com/library/windows/desktop/ms683614)  
+[**InterlockedIncrement64**](https://msdn.microsoft.com/library/windows/desktop/ms683615)  
  
 
  


### PR DESCRIPTION
The line breaks were missing and made the md display the links all on a single line; simply added breaks to improve readability.