### PR TITLE
Update the topic for filtering memory mapped io

### DIFF
--- a/windows-driver-docs-pr/ifs/memory-mapped-files-in-a-file-system-filter-driver.md
+++ b/windows-driver-docs-pr/ifs/memory-mapped-files-in-a-file-system-filter-driver.md
@@ -12,7 +12,7 @@ keywords: ["security WDK file systems , memory mapped files", "memory mapped fil
 ## <span id="ddk_memory_mapped_files_in_a_file_system_filter_driver_if"></span><span id="DDK_MEMORY_MAPPED_FILES_IN_A_FILE_SYSTEM_FILTER_DRIVER_IF"></span>
 
 
-A file system filter driver must be cognizant of the fact that files may be accessed via virtual memory mappings of the files, rather than via the read and write paths. A file system filter driver monitoring changes in the file will miss changes to such files. A number of techniques for dealing with this are discussed in the IFS documentation in the WDK.
+A file system filter driver must be cognizant of the fact that files may be accessed via virtual memory mappings of the files, rather than via the read and write paths. A file system filter driver monitoring changes in the file will miss changes to such files. In general a file system filter driver that wants to deal with memory-mapped I/O has to filter paging I/O. A number of techniques for dealing with this are discussed in the NTFSD (Windows File System Developers List) newsgroup on OSR.
 
  
 


### PR DESCRIPTION
- Adding the general way to filter memory mapped I/O as filtering paging I/O.
- Replace "the IFS documentation in the WDK" with "NTFSD (Windows File System Developers List) newsgroup on OSR" because no one can find such information in WDK.
I discussed this with Christian Allred. So, he or his team might review this.