### PR TITLE
Jack properties use KSP_PIN, not KS_PIN.

### DIFF
--- a/windows-driver-docs-pr/audio/ksproperty-jack-containerid.md
+++ b/windows-driver-docs-pr/audio/ksproperty-jack-containerid.md
@@ -49,8 +49,8 @@ This property can be supported on any bridge pin that is associated with one or 
 <td align="left"><p>Yes</p></td>
 <td align="left"><p>No</p></td>
 <td align="left"><p>Pin factory (via filter handle)</p></td>
-<td align="left"><p>KS_PIN</p></td>
-<td align="left"><p>GUID</p></td>
+<td align="left"><p>[<strong>KSP_PIN</strong>](https://msdn.microsoft.com/library/windows/hardware/ff566722)</p></td>
+<td align="left"><p><strong>GUID</strong></p></td>
 </tr>
 </tbody>
 </table>

--- a/windows-driver-docs-pr/audio/ksproperty-jack-description.md
+++ b/windows-driver-docs-pr/audio/ksproperty-jack-description.md
@@ -49,8 +49,8 @@ In Windows Vista and later, this property can be supported on any bridge pin tha
 <td align="left"><p>Yes</p></td>
 <td align="left"><p>No</p></td>
 <td align="left"><p>Pin factory (via Filter handle)</p></td>
-<td align="left"><p>KS_PIN</p></td>
-<td align="left"><p>[KSMULTIPLE_ITEM](http://msdn.microsoft.com/library/windows/hardware/ff563441.aspx) followed by an array of [<strong>KSJACK_DESCRIPTION</strong>](ksjack-description.md) structures</p></td>
+<td align="left"><p>[<strong>KSP_PIN</strong>](https://msdn.microsoft.com/library/windows/hardware/ff566722)</p></td>
+<td align="left"><p>[<strong>KSMULTIPLE_ITEM</strong>](http://msdn.microsoft.com/library/windows/hardware/ff563441.aspx) followed by an array of [<strong>KSJACK_DESCRIPTION</strong>](ksjack-description.md) structures</p></td>
 </tr>
 </tbody>
 </table>

--- a/windows-driver-docs-pr/audio/ksproperty-jack-description2.md
+++ b/windows-driver-docs-pr/audio/ksproperty-jack-description2.md
@@ -49,8 +49,8 @@ In Windows 7 and later Windows operating systems, this property can be supported
 <td align="left"><p>Yes</p></td>
 <td align="left"><p>No</p></td>
 <td align="left"><p>Pin factory (via filter handle)</p></td>
-<td align="left"><p>KS_PIN</p></td>
-<td align="left"><p>[KSMULTIPLE_ITEM](http://msdn.microsoft.com/library/windows/hardware/ff563441.aspx) followed by an array of [<strong>KSJACK_DESCRIPTION2</strong>](ksjack-description2.md) structures</p></td>
+<td align="left"><p>[<strong>KSP_PIN</strong>](https://msdn.microsoft.com/library/windows/hardware/ff566722)</p></td>
+<td align="left"><p>[<strong>KSMULTIPLE_ITEM</strong>](http://msdn.microsoft.com/library/windows/hardware/ff563441.aspx) followed by an array of [<strong>KSJACK_DESCRIPTION2</strong>](ksjack-description2.md) structures</p></td>
 </tr>
 </tbody>
 </table>

--- a/windows-driver-docs-pr/audio/ksproperty-jack-sink-info.md
+++ b/windows-driver-docs-pr/audio/ksproperty-jack-sink-info.md
@@ -49,7 +49,7 @@ In Windows 7 and later operating systems, this property can be supported on any
 <td align="left"><p>Yes</p></td>
 <td align="left"><p>No</p></td>
 <td align="left"><p>Pin factory (via filter handle)</p></td>
-<td align="left"><p>KS_PIN</p></td>
+<td align="left"><p>[<strong>KSP_PIN</strong>](https://msdn.microsoft.com/library/windows/hardware/ff566722)</p></td>
 <td align="left"><p>[<strong>KSJACK_SINK_INFORMATION</strong>](https://msdn.microsoft.com/library/windows/hardware/ff537140)</p></td>
 </tr>
 </tbody>


### PR DESCRIPTION
The documentation for the four properties in KSPROPSETID_Jack all show that the input is a KS_PIN.  There is no such structure.  It should actually be KSP_PIN.  I added a link to the KSP_PIN page, and set the names to &gt;strong&lt; to match the other pages in this directory.