### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/windows-driver-docs-pr/install/test-signing-a-driver-file.md
+++ b/windows-driver-docs-pr/install/test-signing-a-driver-file.md
@@ -43,7 +43,7 @@ Where:
 
 -   The **/n** *TestCertName* option supplies the name of the test certificate that is installed in the certificate store named *TestCertStoreName*. The test certificate can be either a MakeCert test certificate or a commercial test certificate.
 
--   The **/t** *http://timestamp.digicert.com* option supplies the URL to the publicly-available time-stamp server that VeriSign provides.
+-   The **/t** *http://timestamp.digicert.com* option supplies the URL to the publicly-available time-stamp server that DigiCert provides.
 
 -   *DriverFileName.sys* is the name of the driver file.
 


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.