### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/windows-driver-docs-pr/install/signing-a-catalog-file-with-a-commercial-release-certificate.md
+++ b/windows-driver-docs-pr/install/signing-a-catalog-file-with-a-commercial-release-certificate.md
@@ -29,7 +29,7 @@ Where:
 
 -   The **/n** *CertificateName* option specifies the name of the certificate in the *CertificateStore* certificate store.
 
--   The **/t**  *http://timestamp.digicert.com* option supplies the URL to the publicly-available time-stamp server that VeriSign provides.
+-   The **/t**  *http://timestamp.digicert.com* option supplies the URL to the publicly-available time-stamp server that DigiCert provides.
 
 -   *CatalogFileName.cat* is the name of the catalog file.
 


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.