### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/windows-driver-docs-pr/install/test-signing-a-driver-through-an-embedded-signature.md
+++ b/windows-driver-docs-pr/install/test-signing-a-driver-through-an-embedded-signature.md
@@ -28,7 +28,7 @@ As with [catalog files](catalog-files.md), [**SignTool**](https://docs.microsoft
 To test-sign the *toaster.sys* file, run the following command line:
 
 ```cpp
-Signtool sign /v /fd sha256 /s PrivateCertStore /n Contoso.com(Test) /t http://timestamp.verisign.com/scripts/timestamp.dll amd64\toaster.sys
+Signtool sign /v /fd sha256 /s PrivateCertStore /n Contoso.com(Test) /t http://timestamp.digicert.com amd64\toaster.sys
 ```
 
 Where:
@@ -43,7 +43,7 @@ Where:
 
 -   The **/n** option specifies the name of the certificate (*Contoso.com(Test))* that is installed in the specified certificate store.
 
--   The **/t** option specifies URL of the TSA (*http://timestamp.verisign.com/scripts/timestamp.dll*) which will time stamp the digital signature.
+-   The **/t** option specifies URL of the TSA (*http://timestamp.digicert.com*) which will time stamp the digital signature.
     **Important**   Including a time stamp provides the necessary information for key revocation in case the signer's code signing private key is compromised.
 
      


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.