### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/windows-driver-docs-pr/devtest/signtool.md
+++ b/windows-driver-docs-pr/devtest/signtool.md
@@ -260,7 +260,7 @@ A 32-bit version of SignTool is located in the bin\\i386 folder of the WDK. A 64
 
 The following is an example of how to sign a [driver package's](https://docs.microsoft.com/windows-hardware/drivers/install/driver-packages) catalog file using a Software Publisher Certificate (SPC) and a corresponding cross-certificate. This example is valid for signing a driver package for 64-bit versions of Windows Vista and later versions of Windows, which enforce the kernel-mode code signing policy. The example signs the driver package's catalog file AbcCatFileName.cat. To sign the catalog file, the example uses the cross-certificate AbcCrossCertificate and the AbcSPCCertificate certificate. The AbcSPCCertificate certificate is located in the AbcCertificateStore certificate store.
 
-The example also uses a publicly-available timestamp server to sign the catalog file. The timestamp server is provided by VeriSign and its URL is http://timestamp.digicert.com.
+The example also uses a publicly-available timestamp server to sign the catalog file. The timestamp server is provided by DigiCert and its URL is http://timestamp.digicert.com.
 
 ```
 SignTool sign /ac AbcCrossCertificate.cer /s AbcCertificateStore /n AbcSPCCertificate /t http://timestamp.digicert.com AbcCatFileName.cat


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.