### PR TITLE
Update application-verifier-tests-within-application-verifier.md

### DIFF
--- a/windows-driver-docs-pr/devtest/application-verifier-tests-within-application-verifier.md
+++ b/windows-driver-docs-pr/devtest/application-verifier-tests-within-application-verifier.md
@@ -662,8 +662,6 @@ The following providers do not support ARM64EC, and therefore will crash a progr
 -  [Cuzz](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/application-verifier-tests-within-application-verifier#cuzz)
 -  [LuaPriv](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/application-verifier-tests-within-application-verifier#luapriv)
 -  [Printing](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/application-verifier-tests-within-application-verifier#printing)
--  [WebServices](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/application-verifier-tests-within-application-verifier#webservices)
-
 
 ## See Also
 


### PR DESCRIPTION
Update `Application Verifier - Tests within Application Verifier` to include a list of providers that do not yet support ARM64EC.