### PR TITLE
Kasan: better explain the behavior if KasanEnabled is not set

### DIFF
--- a/windows-driver-docs-pr/devtest/kasan.md
+++ b/windows-driver-docs-pr/devtest/kasan.md
@@ -32,7 +32,7 @@ KASAN is supported only on x64.
    reg add "HKLM\System\CurrentControlSet\Control\Session Manager\Kernel" /v KasanEnabled /t REG_DWORD /d 1
    ```
 
-   This instructs the Windows kernel to prepare for and accept loading KASAN-instrumented drivers. Not setting this registry key causes the Windows kernel to refuse loading KASAN-instrumented drivers.
+   Setting this registry key instructs the Windows kernel to prepare for, and accept loading KASAN instrumented drivers. Not setting this registry key causes the Windows kernel to refuse loading KASAN instrumented drivers.
 
 1. Reboot your target system for the change to take effect.
 


### PR DESCRIPTION
Make it clear that not setting the `KasanEnabled` registry key causes the Windows kernel to refuse loading KASAN-instrumented drivers.