### PR TITLE
Improve the Kasan docs

### DIFF
--- a/windows-driver-docs-pr/debugger/bug-check-0x1f1--kasan-enlightement-violation.md
+++ b/windows-driver-docs-pr/debugger/bug-check-0x1f1--kasan-enlightement-violation.md
@@ -14,7 +14,7 @@ api_type:
 
 # Bug Check 0x1F1: KASAN\_ENLIGHTENMENT\_VIOLATION 
 
-The KASAN\_ENLIGHTENMENT\_VIOLATION bug check has a value of 0x000001F1. It indicates that KASAN enlightenment encoutered a violation when attempting to interact with memory shadow. This bug check is used to check internal operation of KASAN in Windows. For more information, see [Kernel Address Sanitizer (KASAN)](../devtest/kasan.md) and the Microsoft C++ [AddressSanitizer (ASAN)](/cpp/sanitizers/asan) documentation.  
+The KASAN\_ENLIGHTENMENT\_VIOLATION bug check has a value of 0x000001F1. It indicates that KASAN encountered an internal error. This bug check is used to check internal operation of KASAN in Windows. For more information, see [Kernel Address Sanitizer (KASAN)](../devtest/kasan.md) and the Microsoft C++ [AddressSanitizer (ASAN)](/cpp/sanitizers/asan) documentation.
 
 > [!IMPORTANT]
 > This article is for programmers. If you're a customer who has received a blue screen error code while using your computer, see [Troubleshoot blue screen errors](https://www.windows.com/stopcode).
@@ -22,15 +22,14 @@ The KASAN\_ENLIGHTENMENT\_VIOLATION bug check has a value of 0x000001F1. It indi
 
 ## KASAN\_ENLIGHTENMENT\_VIOLATION Parameters
 
-| Parameter |Description                          |
-|---------- |------------------------------------ |
-| 1         | Type of KASAN shadow interaction.   |
-| 2         | Type of violation.                  | 
-| 3         | Extra information on the violation. |
-| 4         | Extra information on the violation. |
+| Parameter |Description                                        |
+|---------- |-------------------------------------------------- |
+| 1         | Type of operation that led to the internal error. |
+| 2         | Type of the internal error.                       |
+| 3         | Extra information on the internal error.          |
+| 4         | Extra information on the internal error.          |
 
 ## See also
 
 - [Kernel Address Sanitizer (KASAN)](../devtest/kasan.md)
 - [Bug Check Code Reference](bug-check-code-reference2.md)
-

--- a/windows-driver-docs-pr/devtest/kasan.md
+++ b/windows-driver-docs-pr/devtest/kasan.md
@@ -78,9 +78,16 @@ In KASAN, we consider that all of the kernel memory is divided in contiguous chu
 |--|--|
 | `0x00` | The cell is entirely valid: accesses to all eight bytes of the cell are legal. |
 | `0x01` -> `0x07` | The cell is partially valid: the first *value* bytes in the cell are valid, but the rest are invalid. |
+| `0x08` -> `0x7F` | The cell is conditionally valid: accesses to all eight bytes of the cell can be legal or illegal depending on specific conditions. |
 | >= `0x80` | The cell is entirely invalid: accesses to all eight bytes of the cell are illegal. |
 
-Several sub-codes are used for the entirely invalid cells to further indicate what type of memory the cell is associated to, and why it is invalid:
+Several sub-codes are used for the conditionally valid and entirely invalid cells to further indicate what type of memory the cell is associated to, and why access to it may be illegal.
+
+Sub-codes used by conditionally valid cells:
+
+ - `0x09`: pageable memory, which is illegal to access at *DISPATCH_LEVEL* or above, but legal to access otherwise.
+
+Sub-codes used by entirely invalid cells:
 
  - `0x81`: left redzone of alloca.
  - `0x82`: middle redzone of alloca.
@@ -88,7 +95,7 @@ Several sub-codes are used for the entirely invalid cells to further indicate wh
  - `0x84`: right redzone of global variable.
  - `0x85`: generic redzone.
  - `0x86`: right redzone of pool memory.
- - `0x87`: freed memory.
+ - `0x87`: freed pool memory.
  - `0x8A`: left redzone of contiguous memory.
  - `0x8B`: right redzone of contiguous memory.
  - `0x8C`: freed lookasidelist memory.


### PR DESCRIPTION
- Improve the accuracy of the KASAN_ENLIGHTENMENT_VIOLATION page, and fix a typo in it.
- Extend the KASAN page to mention conditionally valid cells, and their sub-codes.