### PR TITLE
Reintroduce landing pages for the debugger extension design guides

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -22511,11 +22511,6 @@
       "redirect_document_id": false
     },
     {
-      "source_path": "windows-driver-docs-pr/debugger/dbgeng-extension-design-guide.md",
-      "redirect_url": "/windows-hardware/drivers/debugger/",
-      "redirect_document_id": false
-    },
-    {
       "source_path": "windows-driver-docs-pr/debugger/dbh.md",
       "redirect_url": "/windows-hardware/drivers/debugger/",
       "redirect_document_id": false
@@ -22607,11 +22602,6 @@
     },
     {
       "source_path": "windows-driver-docs-pr/debugger/using-debugger-command-programs.md",
-      "redirect_url": "/windows-hardware/drivers/debugger/",
-      "redirect_document_id": false
-    },
-    {
-      "source_path": "windows-driver-docs-pr/debugger/wdbgexts-extension-design-guide.md",
       "redirect_url": "/windows-hardware/drivers/debugger/",
       "redirect_document_id": false
     },

--- a/windows-driver-docs-pr/debugger/dbgeng-extension-design-guide.md
+++ b/windows-driver-docs-pr/debugger/dbgeng-extension-design-guide.md
@@ -1,0 +1,19 @@
+---
+title: DbgEng Extension Design Guide
+description: DbgEng Extension Design Guide
+keywords: DbgEng Extensions, debugger extensions
+ms.date: 05/23/2017
+ms.topic: concept-article
+---
+
+# DbgEng Extension Design Guide
+
+This section includes:
+
+[Anatomy of a DbgEng Extension DLL](anatomy-of-a-dbgeng-extension-dll.md)
+
+[Using Clients and the Engine](using-clients-and-the-engine.md)
+
+[Writing DbgEng Extension Code](writing-dbgeng-extension-code.md)
+
+[Building DbgEng Extensions](building-dbgeng-extensions.md)

--- a/windows-driver-docs-pr/debugger/toc.yml
+++ b/windows-driver-docs-pr/debugger/toc.yml
@@ -578,6 +578,8 @@
         href: writing-dbgeng-extensions.md
       - name: DbgEng Extension Design Guide
         items:
+        - name: DbgEng Extension Design Guide
+          href: dbgeng-extension-design-guide.md
         - name: Anatomy of a DbgEng Extension DLL
           href: anatomy-of-a-dbgeng-extension-dll.md
         - name: Using Clients and the Engine
@@ -610,6 +612,8 @@
         href: writing-wdbgexts-extensions.md
       - name: WdbgExts Extension Design Guide
         items:
+        - name: WdbgExts Extension Design Guide
+          href: wdbgexts-extension-design-guide.md
         - name: WdbgExts Extension API Overview
           href: wdbgexts-extension-api-overview.md
         - name: 32-Bit Pointers and 64-Bit Pointers

--- a/windows-driver-docs-pr/debugger/wdbgexts-extension-design-guide.md
+++ b/windows-driver-docs-pr/debugger/wdbgexts-extension-design-guide.md
@@ -1,0 +1,23 @@
+---
+title: WdbgExts Extension Design Guide
+description: WdbgExts Extension Design Guide
+keywords: WdbgExts Extensions, debugger extensions
+ms.date: 05/23/2017
+ms.topic: concept-article
+---
+
+# WdbgExts Extension Design Guide
+
+This section includes:
+
+[WdbgExts Extension API Overview](wdbgexts-extension-api-overview.md)
+
+[32-Bit Pointers and 64-Bit Pointers](32-bit-pointers-and-64-bit-pointers.md)
+
+[Using WdbgExts Extension Callbacks](using-wdbgexts-extension-callbacks.md)
+
+[Using the DECLARE_API Macro](using-the-declare-api-macro.md)
+
+[Writing WdbgExts Extension Code](writing-wdbgexts-extension-code.md)
+
+[Building WdbgExts Extensions](building-wdbgexts-extensions.md)


### PR DESCRIPTION
These landing pages only link to the direct subpages, but that works better than having links pointing at those expected landing pages redirect to the "how do I install WinDbg" page.