### PR TITLE
Remove POINTER_ALIGNMENT from PageProtection

### DIFF
--- a/windows-driver-docs-pr/ifs/flt-parameters-for-irp-mj-acquire-for-section-synchronization.md
+++ b/windows-driver-docs-pr/ifs/flt-parameters-for-irp-mj-acquire-for-section-synchronization.md
@@ -25,7 +25,7 @@ typedef union _FLT_PARAMETERS {
   ...    ;
   struct {
     FS_FILTER_SECTION_SYNC_TYPE SyncType;
-    ULONG POINTER_ALIGNMENT     PageProtection;
+    ULONG                       PageProtection;
     PFS_FILTER_SECTION_SYNC_OUTPUT OutputInformation;
   } AcquireForSectionSynchronization;
   ...    ;
@@ -67,3 +67,4 @@ For more information about FSFilter callback operations, see the reference entry
 [**FLT_PARAMETERS**](/windows-hardware/drivers/ddi/fltkernel/ns-fltkernel-_flt_parameters)
 
 [**FsRtlRegisterFileSystemFilterCallbacks**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-fsrtlregisterfilesystemfiltercallbacks)
+


### PR DESCRIPTION
Remove POINTER_ALIGNMENT from PageProtection as this is not the signature from fltKernel.h

This pull request makes a minor update to the documentation for the `FLT_PARAMETERS` union, specifically clarifying the type alignment of the `PageProtection` member in the `AcquireForSectionSynchronization` struct.

- Documentation improvements:
  * In the `FLT_PARAMETERS` union definition in `flt-parameters-for-irp-mj-acquire-for-section-synchronization.md`, removed the `POINTER_ALIGNMENT` macro from the `PageProtection` field to accurately reflect its type and alignment.
  
  from  fltKernel.h:
    //
    //  IRP_MJ_ACQUIRE_FOR_SECTION_SYNCHRONIZATION
    //

    struct {
        FS_FILTER_SECTION_SYNC_TYPE SyncType;
        ULONG PageProtection;
        PFS_FILTER_SECTION_SYNC_OUTPUT OutputInformation;
        ULONG Flags;
        ULONG AllocationAttributes; // Specified if SyncType is SyncTypeCreateSection
    } AcquireForSectionSynchronization;