### PR TITLE
Fix DEVPKEY_Device_DevNodeStatus data type

### DIFF
--- a/windows-driver-docs-pr/install/devpkey-device-devnodestatus.md
+++ b/windows-driver-docs-pr/install/devpkey-device-devnodestatus.md
@@ -37,7 +37,7 @@ The DEVPKEY_Device_DevNodeStatus device property represents the status of a devi
 </tr>
 <tr class="even">
 <td align="left"><p><strong>Property-data-type identifier</strong></p></td>
-<td align="left"><p><a href="devprop-type-int32.md" data-raw-source="[&lt;strong&gt;DEVPROP_TYPE_INT32&lt;/strong&gt;](devprop-type-int32.md)"><strong>DEVPROP_TYPE_INT32</strong></a></p></td>
+<td align="left"><p><a href="devprop-type-uint32.md" data-raw-source="[&lt;strong&gt;DEVPROP_TYPE_UINT32&lt;/strong&gt;](devprop-type-uint32.md)"><strong>DEVPROP_TYPE_UINT32</strong></a></p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p><strong>Property access</strong></p></td>
@@ -74,4 +74,5 @@ Windows Server 2003, Windows XP, and Windows 2000 do not directly support this p
 [**SetupDiGetDeviceProperty**](/windows/win32/api/setupapi/nf-setupapi-setupdigetdevicepropertyw)
 
  
+
 


### PR DESCRIPTION
`devpkey.h`  says that this is uint32 and my Windows 11 agrees