### PR TITLE
Clarify Inf2Cat tool location and remove outdated Windows Kits paths

### DIFF
--- a/windows-driver-docs-pr/bringup/authoring-an-update-driver-package.md
+++ b/windows-driver-docs-pr/bringup/authoring-an-update-driver-package.md
@@ -153,7 +153,8 @@ The steps to self-sign the driver package for test purposes are enumerated below
 
     `%WindowsSdkDir%\bin\<version>\x86` (or `x64`)
 
-    > Note: The exact SDK version folder and the set of available tools depend on the installed Windows SDK/WDK components.
+    > [!NOTE]
+    > The exact SDK version folder and the set of available tools depend on the installed Windows SDK/WDK components.
 
 1. Run the following command to create a test certificate.
 

--- a/windows-driver-docs-pr/bringup/authoring-an-update-driver-package.md
+++ b/windows-driver-docs-pr/bringup/authoring-an-update-driver-package.md
@@ -144,7 +144,16 @@ Once the driver package INF file and firmware payload binary are ready, the enti
 
 The steps to self-sign the driver package for test purposes are enumerated below. Please note that these steps are for test purposes only. In production, firmware update driver packages must be submitted to the Partner Center for signing. For the steps to sign a firmware driver package for production see [Certifying and signing the update package](certifying-and-signing-the-update-package.md).
 
-1. Install the latest Windows SDK and Windows Driver Kit. This will install the makecert, pvk2pfx inf2cat and signtool tools under `%systemdir%\Program Files (x86)\Windows Kits\<*version*>\bin\x86`.
+1. Install the latest Windows SDK and Windows Driver Kit (WDK).
+
+    - The Windows SDK installs tools such as `makecert`, `pvk2pfx`, and `signtool`.
+    - The Windows Driver Kit (WDK) installs driver-specific tools such as `Inf2Cat`.
+
+    You can typically find these tools under the Windows Kits installation directory, for example:
+
+    `%WindowsSdkDir%\bin\<version>\x86` (or `x64`)
+
+    > Note: The exact SDK version folder and the set of available tools depend on the installed Windows SDK/WDK components.
 
 1. Run the following command to create a test certificate.
 

--- a/windows-driver-docs-pr/devtest/inf2cat.md
+++ b/windows-driver-docs-pr/devtest/inf2cat.md
@@ -29,7 +29,8 @@ find it under the Windows Kits installation directory, for example:
 
 `%WindowsSdkDir%\bin\<version>\x86` (or `x64`)
 
-> Note: The exact SDK version folder depends on the installed Windows SDK/WDK components.
+> [!Note]
+> The exact SDK version folder depends on the installed Windows SDK/WDK components.
 
 ## Troubleshooting
 

--- a/windows-driver-docs-pr/devtest/inf2cat.md
+++ b/windows-driver-docs-pr/devtest/inf2cat.md
@@ -24,7 +24,12 @@ Inf2Cat (Inf2Cat.exe) is a command-line tool that determines whether a [driver p
     WindowsVersionList [/nocat] [/verbose] [/?] [other switches]
 ```
 
-The Inf2Cat tool is located in the Program Files\\Windows Kits\\8.0\\bin\\x86 or Program Files (x86)\\Windows Kits\\8.0\\bin\\x86 folder of the WDK.
+The Inf2Cat tool is installed with the Windows Driver Kit (WDK). You can typically
+find it under the Windows Kits installation directory, for example:
+
+`%WindowsSdkDir%\bin\<version>\x86` (or `x64`)
+
+> Note: The exact SDK version folder depends on the installed Windows SDK/WDK components.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Description

Removes an outdated hardcoded Windows Kits 8.0 location and incorrect %systemdir%-based path wording.

Clarifies that Inf2Cat is installed with the WDK, while signtool and pvk2pfx are part of the Windows SDK.

Uses a version-agnostic Windows Kits location example under %WindowsSdkDir%\bin\<version>\x86|x64.