### PR TITLE
MSFT_Volume.Format returns error code 43034 but the documentation is missing

### DIFF
--- a/windows-driver-docs-pr/storage/format-msft-volume.md
+++ b/windows-driver-docs-pr/storage/format-msft-volume.md
@@ -196,7 +196,8 @@ This parameter allows the storage provider to return extended (implementation-sp
  
 
 **Cannot perform the requested operation when the drive is read only** (43006)
- 
+
+**Missing documentation** (43034)
 
 ## Requirements
 


### PR DESCRIPTION
Hi.

MSFT_Volume.Format returns error code 43034 but the documentation for error code 43034 is missing.

What does error code 43034 actually mean?

Thank you.