### PR TITLE
Fixed a minor typo for one of the links

### DIFF
--- a/windows-driver-docs-pr/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates.md
+++ b/windows-driver-docs-pr/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates.md
@@ -16,8 +16,7 @@ ms.custom: sfi-image-nochange
 
 The [Microsoft Trusted Root Program](/security/trusted-root/program-requirements) no longer supports root certificates that have kernel mode signing capabilities.
 
-For policy requirements, see [Windows 10 kernel mode code signing requirements]
-(/security/trusted-root/program-requirements#f-windows-10-kernel-mode-code-signing-kmcs-requirements).
+For policy requirements, see [Windows 10 kernel mode code signing requirements](/security/trusted-root/program-requirements#f-windows-10-kernel-mode-code-signing-kmcs-requirements).
 
 Existing [cross-signed root certificates](cross-certificates-for-kernel-mode-code-signing.md) with kernel-mode code-signing capabilities continue to work until expiration. All software publisher certificates, commercial release certificates, and commercial test certificates that chain back to these root certificates also become invalid on the same schedule.
 


### PR DESCRIPTION
The link for "For policy requirement"... incorrectly had a CR between the square-bracket and parentheis parts of the link. 

This causes the link to be displayed as text and not as a real link