### PR TITLE
Fix and remove broken links in gflags.md

### DIFF
--- a/windows-driver-docs-pr/debugger/gflags.md
+++ b/windows-driver-docs-pr/debugger/gflags.md
@@ -39,7 +39,7 @@ GFlags supports the following features:
 
 ### Requirements
 
-To use most GFlags features, you must be a member of the Administrator's group on the computer. For example, to set flags in the registry or in kernel mode, or enable page heap verification.
+To use most GFlags features, you must be a member of the Administrators group on the computer. For example, to set flags in the registry or in kernel mode, or enable page heap verification.
 
 > [!NOTE]
 > Incorrect use of the GFlags tool can degrade system performance or prevent Windows from starting, which might require you to reinstall Windows.
@@ -58,12 +58,9 @@ This section includes:
 
 - [Global Flags dialog](global-flags-dialog-box.md)
 
-- [GFlags examples](gflags-examples.md)
-
-- [Global Flag reference](global-flag-reference.md)
+- [GFlags examples](example-1---displaying-global-flags.md)
 
 ## Related articles
 
-- [GFlags examples](gflags-examples.md)
-- [Global flag reference](global-flag-reference.md)
+- [GFlags examples](example-1---displaying-global-flags.md)
 - [Tools included in Debugging Tools for Windows](extra-tools.md)


### PR DESCRIPTION
This change fixes or removes some broken links from https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags 

Links to the `global-flag-reference.md` file are broken, this file doesn't seem to exist in this repo currently. (A search for this file in the github website doesn't find any commit where it could have been renamed or deleted, I have yet to clone the repo to search every commit locally.)

There's no index page for all of the GFlags Examples, so instead I link to the first example doc. (This probably requires a pass over other files which link to this file as well)

Additionally, the name of the Administrators group includes the trailing `s`, it's not possessive. This matches the name of the spelling as it appears under "Local Users and Groups".