### PR TITLE
Revise technical support guide for Partner Center

### DIFF
--- a/windows-driver-docs-pr/dashboard/technical-support.md
+++ b/windows-driver-docs-pr/dashboard/technical-support.md
@@ -39,7 +39,7 @@ Microsoft Engage Center is the fastest path to reach the Hardware Program suppor
 
 If you can't sign in to Engage Center with an account that is enrolled in the Hardware Program — for example, your enrollment is incomplete, you can't access the enrolled tenant, or you're trying to enroll for the first time — open a case through Partner Center support instead.
 
-1. Go to Partner Center support: [https://partner.microsoft.com/en-us/support](https://partner.microsoft.com/en-us/support?stage=2&topicid=abf19e05-3f3a-f111-88b3-000d3a16941b).
+1. Go to [Partner Center support](https://partner.microsoft.com/support?stage=2&topicid=abf19e05-3f3a-f111-88b3-000d3a16941b).
 
 2. Under **Next Step** choose the option to 'Provide issue details'
 

--- a/windows-driver-docs-pr/dashboard/technical-support.md
+++ b/windows-driver-docs-pr/dashboard/technical-support.md
@@ -1,22 +1,46 @@
 ---
 title: Support for Partner Center Dashboard
-description: Follow these steps to get Windows developer support for Partner Center dashboard issues.
+description: How to open a support case for Hardware Program partners using the Partner Center dashboard — including the fastest path through Microsoft Engage Center and the fallback for enrollment issues through Partner Center support.
 ms.custom: "se-defect-target"
-ms.date: 10/16/2025
+ms.date: 05/27/2026
 ms.topic: how-to
 ---
 
-# Support for Partner Center dashboard
+# Get support for the Hardware Program & Hardware Dev Center
 
-Follow these steps to get Windows developer support for Partner Center dashboard issues.
+The Windows Hardware Program & Hardware Dev Center (HDC) provide enrolled partners with the ability to sign and publish drivers into the Windows ecosystem. Follow these steps to get Microsoft support for issues in the Partner Center dashboard — including driver submissions, signing, publishing, and account/enrollment questions.
 
-## Get support for dashboard
+There are two ways to open a support case:
 
-1. Go to [Windows developer support](https://developer.microsoft.com/windows/support/?tabs=Contact-us).
-1. In the *Non-Technical Support-Dashboard* section, select **Ask Copilot**.
+- **Open a case directly with program support via Engage Center** (You must be signed in with a Partner Center account that is enrolled in the Hardware Program → use [Microsoft Engage Center](https://engagecenter.microsoft.com/#view/Microsoft_AzureCXP_EngageHub/EngageHubMenu.MenuView/targetExperience/sfb/sapId/bc9d4067-7218-61b9-1d2c-68ae591acf9d) *(fastest resolution)*.
+- **You can't sign in with an account that has completed enrollment in the Hardware Program** (for example, your enrollment is incomplete, your account is suspended, or you can't access the enrolled tenant) → use [Partner Center support](#cant-sign-in-with-an-enrolled-account-open-a-partner-center-enrollment-case).
 
-    :::image type="content" source="images/hardware-submission-support/dashboard-submit-incident.png" alt-text="Screenshot showing the Ask Copilot link for dashboard support.":::
+## Open a case in Microsoft Engage Center (recommended)
 
-1. Sign in with your Partner Center account.
-1. Copy and paste the validation code into the Copilot chat field, as instructed.
-1. Ask Copilot your question. If Copilot can't answer your question, it will provide a link to open a support ticket.
+Microsoft Engage Center is the fastest path to reach the Hardware Program support team.
+
+1. Go to the Hardware Program support creation form in [Microsoft Engage Center](https://engagecenter.microsoft.com/#view/Microsoft_AzureCXP_EngageHub/EngageHubMenu.MenuView/targetExperience/sfb/sapId/bc9d4067-7218-61b9-1d2c-68ae591acf9d)
+
+2. Sign in with your **Partner Center account that is enrolled in the Hardware Program**.
+
+   > [NOTE]
+   > You must sign in with an account that is enrolled in the Hardware Program. If you sign in with a different account, you will be blocked selecting the correct routing choices during the creation workflow. If you can't sign in with an enrolled account, follow the steps in below instead.
+
+3. When creating the case, select the following values:
+
+   | Field | Value |
+   |---|---|
+   | Product | **Windows Developer Center** |
+   | Problem Type | **Hardware Device Drivers** |
+
+4. Complete the form and submit the case. A confirmation email with a support request number will be sent to the contacts confirming receipt of the submission.
+
+## Can't sign in with an enrolled account? Open a Partner Center enrollment case
+
+If you can't sign in to Engage Center with an account that is enrolled in the Hardware Program — for example, your enrollment is incomplete, you can't access the enrolled tenant, or you're trying to enroll for the first time — open a case through Partner Center support instead.
+
+1. Go to Partner Center support: [https://partner.microsoft.com/en-us/support](https://partner.microsoft.com/en-us/support?stage=2&topicid=abf19e05-3f3a-f111-88b3-000d3a16941b).
+
+2. Under **Next Step** choose the option to 'Provide issue details'
+
+3. Complete the form and submit the case. A confirmation email with a support request number will be sent to the contacts confirming receipt of the submission.

--- a/windows-driver-docs-pr/dashboard/technical-support.md
+++ b/windows-driver-docs-pr/dashboard/technical-support.md
@@ -23,7 +23,7 @@ Microsoft Engage Center is the fastest path to reach the Hardware Program suppor
 
 2. Sign in with your **Partner Center account that is enrolled in the Hardware Program**.
 
-   > [NOTE]
+   > [!NOTE]
    > You must sign in with an account that is enrolled in the Hardware Program. If you sign in with a different account, you are blocked from selecting the correct routing choices during the creation workflow. If you can't sign in with an enrolled account, use the following steps instead.
 
 3. When creating the case, select the following values:

--- a/windows-driver-docs-pr/dashboard/technical-support.md
+++ b/windows-driver-docs-pr/dashboard/technical-support.md
@@ -24,7 +24,7 @@ Microsoft Engage Center is the fastest path to reach the Hardware Program suppor
 2. Sign in with your **Partner Center account that is enrolled in the Hardware Program**.
 
    > [NOTE]
-   > You must sign in with an account that is enrolled in the Hardware Program. If you sign in with a different account, you will be blocked selecting the correct routing choices during the creation workflow. If you can't sign in with an enrolled account, follow the steps in below instead.
+   > You must sign in with an account that is enrolled in the Hardware Program. If you sign in with a different account, you are blocked from selecting the correct routing choices during the creation workflow. If you can't sign in with an enrolled account, use the following steps instead.
 
 3. When creating the case, select the following values:
 
@@ -41,6 +41,6 @@ If you can't sign in to Engage Center with an account that is enrolled in the Ha
 
 1. Go to [Partner Center support](https://partner.microsoft.com/support?stage=2&topicid=abf19e05-3f3a-f111-88b3-000d3a16941b).
 
-2. Under **Next Step** choose the option to 'Provide issue details'
+2. Under **Next Step**, choose the option **Provide issue details**
 
-3. Complete the form and submit the case. A confirmation email with a support request number will be sent to the contacts confirming receipt of the submission.
+3. Complete the form and submit the case. A confirmation email with a support request number is sent to the contacts.

--- a/windows-driver-docs-pr/dashboard/technical-support.md
+++ b/windows-driver-docs-pr/dashboard/technical-support.md
@@ -13,7 +13,7 @@ The Windows Hardware Program & Hardware Dev Center (HDC) provide enrolled partne
 There are two ways to open a support case:
 
 - **Open a case directly with program support via Engage Center** (You must be signed in with a Partner Center account that is enrolled in the Hardware Program → use [Microsoft Engage Center](https://engagecenter.microsoft.com/#view/Microsoft_AzureCXP_EngageHub/EngageHubMenu.MenuView/targetExperience/sfb/sapId/bc9d4067-7218-61b9-1d2c-68ae591acf9d) *(fastest resolution)*.
-- **You can't sign in with an account that has completed enrollment in the Hardware Program** (for example, your enrollment is incomplete, your account is suspended, or you can't access the enrolled tenant) → use [Partner Center support](#cant-sign-in-with-an-enrolled-account-open-a-partner-center-enrollment-case).
+- **You can't sign in with an account that has completed enrollment in the Hardware Program** (for example, your enrollment is incomplete, your account is suspended, or you can't access the enrolled tenant) → use [Partner Center support](https://partner.microsoft.com/support?stage=2&topicid=abf19e05-3f3a-f111-88b3-000d3a16941b).
 
 ## Open a case in Microsoft Engage Center (recommended)
 


### PR DESCRIPTION
Updated the technical support documentation for the Partner Center dashboard (HDC), explaining how to use the new Engage Center for submitting a support request.