### PR TITLE
Fix incorrect documentation for `EFI_RNG_GET_RNG`

### DIFF
--- a/windows-driver-docs-pr/bringup/efi-rng-protocol-getrng.md
+++ b/windows-driver-docs-pr/bringup/efi-rng-protocol-getrng.md
@@ -29,14 +29,10 @@ typedef EFI_STATUS (EFIAPI *EFI_RNG_GET_RNG) (
 [in] A pointer to the EFI_RNG_ALGORITHM which identifies the RNG algorithm to use. If this parameter is NULL, the default algorithm supported by the driver will be used.
 
 *RNGValueLength*  
-[in] The length, in bytes, of the buffer returned by *RNGValue*.
+[in] The length, in bytes, of the buffer pointed to by *RNGValue*. The driver shall return exactly this many bytes.
 
 *RNGValue*  
-[in] Pointer to a buffer that will contain the RNG value. The value is allocated by this function using EFI_BOOT_SERVICES->AllocatePool(), and it is the caller's responsibility to free this memory by using EFI_BOOT_SERVICES->FreePool().
-
-## Remarks
-
-The minimum size of *RNGValue* is 32 bytes.
+[out] Pointer to a buffer to fill with random bytes.
 
 ## Return value
 
@@ -45,11 +41,10 @@ Returns one of the following status codes.
 | Status code | Description |
 |--|--|
 | EFI_SUCCESS | The function successfully returned an RNG value. |
-| EFI_INVALID_PARAMETER | *RNGAlgorithm* is NULL when several algorithms are possible. |
 | EFI_UNSUPPORTED | The algorithm specified by *RNGAlgorithm* is not supported by this driver. |
 | EFI_DEVICE_ERROR | An RNG value could not be retrieved because of a hardware or firmware error. |
 | EFI_NOT_READY | There is not enough entropy data available. |
-| EFI_OUT_OF_RESOURCES | The driver is unable to allocate memory for the RNG value. |
+| EFI_INVALID_PARAMETER | *RNGValue* is null or *RNGValueLength* is zero. |
 
 ## Requirements
 


### PR DESCRIPTION
`EFI_RNG_GET_RNG` is incorrectly described as returning an allocated
buffer that the caller must free. It fills in a user-provided buffer.

Update the documentation and error codes, based on
<https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-protocol-getrng>.

---

`EFI_RNG_GET_INFO` appears to have a similar bug, and needs updating from
<https://uefi.org/specs/UEFI/2.11/37_Secure_Technologies.html#efi-rng-protocol-getinfo>
. One bug at a time, though; this PR is for the bug I actually ran into.
