### PR TITLE
Clarify Command Prompt support for WinGet configuration

### DIFF
--- a/windows-driver-docs-pr/install-the-wdk-using-winget.md
+++ b/windows-driver-docs-pr/install-the-wdk-using-winget.md
@@ -22,10 +22,11 @@ You can use the Windows Package Manager (WinGet) to install the Windows Driver K
 
 ## Install a full driver development environment using a WinGet configuration file
 
-Run the following command in PowerShell to install the WDK and all of its dependencies at once:
+Run the following command in PowerShell or Command Prompt to install the WDK and all of its dependencies at once:
 
-```powershell
-winget configure -f 'https://raw.githubusercontent.com/microsoft/Windows-driver-samples/main/_wdk_utils/winget/configs/wdk-vscommunity.dsc.yaml'
+
+```console
+winget configure -f "https://raw.githubusercontent.com/microsoft/Windows-driver-samples/main/_wdk_utils/winget/configs/wdk-vscommunity.dsc.yaml"
 ```
 
 This [configuration file](https://github.com/microsoft/Windows-driver-samples/blob/main/_wdk_utils/winget/configs/wdk-vscommunity.dsc.yaml) sets up the following components:


### PR DESCRIPTION
## Summary

Update the WinGet configuration command to use double quotes and clarify that it can be run in either PowerShell or Command Prompt.

## Details

The current command uses PowerShell-style single quotes around the configuration file URL. In Command Prompt, the single quotes are passed as part of the file path, causing WinGet to report that the file does not exist.

Double quotes work correctly in both PowerShell and Command Prompt.

## Testing

Tested the updated `winget configure` command in both PowerShell and Command Prompt.
