### PR TITLE
btvs: document keys to revert the configuration

### DIFF
--- a/windows-driver-docs-pr/bluetooth/testing-BTP-tools-btvs.md
+++ b/windows-driver-docs-pr/bluetooth/testing-BTP-tools-btvs.md
@@ -45,6 +45,18 @@ There are two buttons on the Bluetooth Virtual Sniffer window:
 
     For a limited time, enable SSP debug mode. Send and accept SMP debug keys. Clicking again extends the time.
 
+## Associated registry keys
+
+The following keys are located in `HKLM:\SYSTEM\CurrentControlSet\Services\BthPort\Parameters`. They are set when clicking on buttons of the user interface, and can be used to revert the changes.
+
+| Value | Type | Meaning | Notes |
+| ----- | ---- | ------- | ----- |
+| `MaxEtwBytes` | DWORD | The maximum size of a HCI packet. | "Full Packet Logging" sets this to 0x400 |
+| `EtwLogSensitiveData` | DWORD | Set to 1 to enable HCI logging of sensitive data. Defaults to 0. | |
+| `EtwDropLargeEvents` | DWORD | Set to 0 to not drop large HCI packets. Defaults to 1. | |
+| `SimplePairingDebugEnabled` | DWORD | Set to 1 to enable SSP debug mode. Defaults to 0. | |
+| `SmpDebugEnabled` | DWORD | Send and accept SMP debug keys. Defaults to 0. | |
+
 ## Wireshark operation
 
 Assumes Wireshark is installed.


### PR DESCRIPTION
Clicking on the `btvs.exe` user interface sets some registry keys which may not be reverted (if closed unexpectedly for instance). It sounds very useful to document those so that a revert is possible.